### PR TITLE
Update header in lighting.ipynb

### DIFF
--- a/docs/source/examples/lighting.ipynb
+++ b/docs/source/examples/lighting.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lightning\n",
+    "# Lighting\n",
     "By default ipyvolume uses a fake lighting model that works ok for depth perception. To get more realistic lighting effects ipyvolume supports a few light models from pythreejs/threejs.\n"
    ]
   },


### PR DESCRIPTION
Was looking through the docs and noticed "Lighting" has been misspelled as "Lightning" in the page header.